### PR TITLE
Type hinting for nn_finder.py module and associated functions

### DIFF
--- a/src/pynnmap/cli/cross_validate.py
+++ b/src/pynnmap/cli/cross_validate.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import click
 
 from ..core.nn_finder import PixelNNFinder, PlotNNFinder
@@ -6,19 +8,19 @@ from ..diagnostics import diagnostic_wrapper as dw
 from ..parser import parameter_parser_factory as ppf
 
 
-def run_cross_validate(parser, finder):
+def run_cross_validate(parser, finder: PixelNNFinder | PlotNNFinder) -> None:
     # Run cross-validation to create the neighbor/distance information
     neighbor_data = finder.calculate_neighbors_cross_validation()
 
     # Calculate independent and dependent predictive accuracy
-    output = IndependentOutput(parser, neighbor_data)
-    output.write_zonal_records(parser.independent_zonal_pixel_file)
-    output.write_attribute_predictions(parser.independent_predicted_file)
+    independent_output = IndependentOutput(parser, neighbor_data)
+    independent_output.write_zonal_records(parser.independent_zonal_pixel_file)
+    independent_output.write_attribute_predictions(parser.independent_predicted_file)
 
-    output = DependentOutput(parser, neighbor_data)
-    output.write_zonal_records(parser.dependent_zonal_pixel_file)
-    output.write_attribute_predictions(parser.dependent_predicted_file)
-    output.write_nn_index_file(neighbor_data, parser.dependent_nn_index_file)
+    dependent_output = DependentOutput(parser, neighbor_data)
+    dependent_output.write_zonal_records(parser.dependent_zonal_pixel_file)
+    dependent_output.write_attribute_predictions(parser.dependent_predicted_file)
+    dependent_output.write_nn_index_file(neighbor_data, parser.dependent_nn_index_file)
 
 
 @click.command(name="cross-validate", short_help="Accuracy assessment for model plots")

--- a/src/pynnmap/core/__init__.py
+++ b/src/pynnmap/core/__init__.py
@@ -4,14 +4,14 @@ import pandas as pd
 from .independence_filter import IndependenceFilter
 
 
-def get_id_year_crosswalk(parser):
+def get_id_year_crosswalk(parser) -> dict[int, int]:
     id_field = parser.plot_id_field
     xwalk_df = pd.read_csv(parser.plot_year_crosswalk_file, low_memory=False)
     if parser.model_type in parser.imagery_model_types:
         s = pd.Series(xwalk_df.IMAGE_YEAR.values, index=xwalk_df[id_field])
     else:
         s = pd.Series(parser.model_year, index=xwalk_df[id_field])
-    return dict(s.to_dict())
+    return s.to_dict()
 
 
 def get_independence_filter(parser, no_self_assign_field="LOC_ID"):

--- a/src/pynnmap/core/imputation_model.py
+++ b/src/pynnmap/core/imputation_model.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import numpy as np
+from numpy.typing import NDArray
 from sklearn.neighbors import NearestNeighbors
 
 
@@ -37,7 +40,9 @@ class ImputationModel:
         # Lookup of index to plot ID to get correct neighbor IDs
         self.ipd = ord_model.id_plot_dict
 
-    def get_neighbors(self, env_values, id_val=None):
+    def get_neighbors(
+        self, env_values: NDArray, id_val: int | None = None
+    ) -> tuple[NDArray, NDArray]:
         """
         Given the vector of env_values, return the sorted neighbors and
         distances for this vector.  If id is specified, ensure that if the


### PR DESCRIPTION
The `nn_finder.py` module does a lot of data extraction and passing with somewhat complicated data structures.  This PR provides type hinting for all functions and classes within `nn_finder.py` and other functions or classes used from this module.  

Additionally, this PR fixes an issue when a single raster path is used for more than one covariate.  For example, a imagery band like `TC1` could be used in a model both for the current year as well as the previous year (model covariates `TC1` and `TC1_PREV`).  Data structures within `extract_footprints` were creating a dictionary from path to a single model variable name and this has been changed to be a dictionary from path to a set of model variable by year tuples.