### PR TITLE
Use `sknnr` to run canonical correspondence analysis (CCA)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "rpy2",
     "scikit-learn",
     "scipy",
+    "sknnr",
 ]
 
 [project.scripts]
@@ -56,10 +57,15 @@ packages = ["src/pynnmap"]
 include = ["/src"]
 
 [tool.hatch.envs.default]
-dependencies = ["pre-commit"]
+dependencies = [
+    "pre-commit",
+]
 
 [tool.hatch.envs.test]
-dependencies = ["pytest", "pytest-cov"]
+dependencies = [
+    "pytest",
+    "pytest-cov",
+]
 
 [tool.hatch.envs.test.scripts]
 all = "pytest . {args} --doctest-modules"

--- a/src/pynnmap/cli/build_model.py
+++ b/src/pynnmap/cli/build_model.py
@@ -9,7 +9,6 @@ ORD_DICT = {
     ("vegan", "CCA"): ordination.VeganCCAOrdination,
     ("vegan", "RDA"): ordination.VeganRDAOrdination,
     ("vegan", "DBRDA"): ordination.VeganDBRDAOrdination,
-    ("numpy", "CCA"): ordination.NumpyCCAOrdination,
     ("numpy", "RDA"): ordination.NumpyRDAOrdination,
     ("sknnr", "CCA"): ordination.SknnrCCAOrdination,
 }

--- a/src/pynnmap/cli/build_model.py
+++ b/src/pynnmap/cli/build_model.py
@@ -11,6 +11,7 @@ ORD_DICT = {
     ("vegan", "DBRDA"): ordination.VeganDBRDAOrdination,
     ("numpy", "CCA"): ordination.NumpyCCAOrdination,
     ("numpy", "RDA"): ordination.NumpyRDAOrdination,
+    ("sknnr", "CCA"): ordination.SknnrCCAOrdination,
 }
 
 

--- a/src/pynnmap/cli/build_model.py
+++ b/src/pynnmap/cli/build_model.py
@@ -9,6 +9,7 @@ ORD_DICT = {
     ("vegan", "CCA"): ordination.VeganCCAOrdination,
     ("vegan", "RDA"): ordination.VeganRDAOrdination,
     ("vegan", "DBRDA"): ordination.VeganDBRDAOrdination,
+    ("numpy", "CCA"): ordination.NumpyCCAOrdination,
     ("numpy", "RDA"): ordination.NumpyRDAOrdination,
     ("sknnr", "CCA"): ordination.SknnrCCAOrdination,
 }

--- a/src/pynnmap/core/ordination.py
+++ b/src/pynnmap/core/ordination.py
@@ -205,11 +205,6 @@ class NumpyOrdination(Ordination):
                 numpy_fh.write(f"{plot},{weight},{n2}\n")
 
 
-class NumpyCCAOrdination(NumpyOrdination):
-    ordination_cls = numpy_ordination.NumpyCCA
-    ordination_prefix = "CCA"
-
-
 class NumpyRDAOrdination(NumpyOrdination):
     ordination_cls = numpy_ordination.NumpyRDA
     ordination_prefix = "RDA"

--- a/src/pynnmap/core/ordination.py
+++ b/src/pynnmap/core/ordination.py
@@ -177,7 +177,7 @@ class ConstrainedOrdinationOutputWriterMixin:
     def write_eigenvalues(self, fh, eigenvalues):
         fh.write("### Eigenvalues ###\n")
         for i, e in enumerate(eigenvalues):
-            fh.write(f"{self.prefix}{i+1},{e:.10f}\n")
+            fh.write(f"{self.prefix}{i+1},{e:.8f}\n")
         fh.write("\n")
 
     def write_variable_means(self, fh, env_names, variable_means):
@@ -191,8 +191,8 @@ class ConstrainedOrdinationOutputWriterMixin:
         fh.write("SPECIES,WEIGHT,N2\n")
         for i in range(len(species_weights)):
             column = species_names[i]
-            weight = f"{species_weights[i]:.10f}"
-            n2 = f"{species_n2[i]:.10f}"
+            weight = f"{species_weights[i]:.5f}"
+            n2 = f"{species_n2[i]:.5f}"
             fh.write(f"{column},{weight},{n2}\n")
         fh.write("\n")
 
@@ -201,8 +201,8 @@ class ConstrainedOrdinationOutputWriterMixin:
         fh.write("ID,WEIGHT,N2\n")
         for i in range(len(site_weights)):
             plot = plot_ids[i]
-            weight = f"{site_weights[i]:.10f}"
-            n2 = f"{site_n2[i]:.10f}"
+            weight = f"{site_weights[i]:.6f}"
+            n2 = f"{site_n2[i]:.6f}"
             fh.write(f"{plot},{weight},{n2}\n")
 
     def write_cca_section(

--- a/src/pynnmap/core/ordination.py
+++ b/src/pynnmap/core/ordination.py
@@ -309,16 +309,6 @@ class SknnrCCAOrdination(Ordination):
         # Create the transformation object
         cca = CCATransformer().fit(env, spp)
 
-        # TODO: This belongs in sknnr
-        species_weights = np.sum(spp, axis=0)
-        a = np.square(np.divide(spp, species_weights))
-        species_n2 = 1.0 / a.sum(axis=0)
-
-        # TODO: This belongs in sknnr
-        site_weights = np.sum(spp, axis=1)
-        a = np.square(np.divide(spp, np.expand_dims(site_weights, axis=1)))
-        site_n2 = 1.0 / a.sum(axis=1)
-
         ordination_results = ConstrainedOrdinationResults(
             prefix="CCA",
             rank=cca.ordination_.rank,
@@ -331,11 +321,11 @@ class SknnrCCAOrdination(Ordination):
             biplot_scores=cca.ordination_.biplot_scores,
             species_centroids=cca.ordination_.species_scores,
             species_tolerances=cca.ordination_.species_tolerances,
-            species_weights=species_weights,
-            species_n2=species_n2,
+            species_weights=cca.ordination_.species_weights,
+            species_n2=cca.ordination_.species_n2,
             site_lc_scores=cca.ordination_.site_lc_scores,
             site_wa_scores=cca.ordination_.site_wa_scores,
-            site_weights=site_weights,
-            site_n2=site_n2,
+            site_weights=cca.ordination_.site_weights,
+            site_n2=cca.ordination_.site_n2,
         )
         ordination_results.write_output(self.parameters.ordination_file)

--- a/src/pynnmap/parser/xml_parameter_parser.py
+++ b/src/pynnmap/parser/xml_parameter_parser.py
@@ -460,7 +460,11 @@ class XMLParameterParser(xml_parser.XMLParser, parameter_parser.ParameterParser)
             return None
 
     def get_ordination_file(self):
-        file_xwalk = {"vegan": "vegan_file", "numpy": "numpy_file"}
+        file_xwalk = {
+            "vegan": "vegan_file",
+            "numpy": "numpy_file",
+            "sknnr": "sknnr_file",
+        }
         ord_program = self.ordination_program
         program_elem = self.ordination_program_element
         try:


### PR DESCRIPTION
This PR brings [sknnr](https://github.com/lemma-osu/sknnr) in as a dependency of `pynnmap` and uses sknnr's `CCATransformer` to create the needed CCA output files.  Note that this is an initial step to getting `sknnr` fully integrated within `pynnmap` and `sknnr` is not yet responsible for tasks like finding `kneighbors` or `predict`.  

The new `SknnrCCAOrdination` class is responsible for reading in the species and environment matrices and creating output compatiable with previously produced vegan output.  Although we don't have tests that prove correctness, we have verified that the output ordination file matches vegan output and that running `pynnmap cross-validate` produces identical (within precision) results as running with vegan output.  

We have not yet deprecated or removed vegan or custom numpy-based CCA methods, but the goal is to have a single source of ordination provided by the `sknnr` package.