### PR TITLE
Implement `new-targets` CLI entry point

### DIFF
--- a/src/pynnmap/cli/new_targets.py
+++ b/src/pynnmap/cli/new_targets.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import click
 import pandas as pd
 
-from ..core.nn_finder import PixelNNFinder, PlotNNFinder
+from ..core.nn_finder import PixelNNFinder
 from ..core.prediction_output import DependentOutput, IndependentOutput
 from ..parser import parameter_parser_factory as ppf
 
 
 def run_new_targets(
     parser,
-    finder: PixelNNFinder | PlotNNFinder,
+    finder: PixelNNFinder,
     target_fcids: list[int],
     output_predicted_prefix: str,
     output_zonal_prefix: str,
@@ -35,12 +35,6 @@ def run_new_targets(
 @click.command(
     name="new-targets", short_help="Run accuracy assessment on independent plots"
 )
-@click.option(
-    "--scale",
-    type=click.Choice(["PIXEL", "PLOT"], case_sensitive=False),
-    default="PIXEL",
-    help="Calculate accuracy at pixel or plot scale",
-)
 @click.argument("parameter-file", type=click.Path(exists=True), required=True)
 @click.argument("target-plot-file", type=click.Path(exists=True), required=True)
 @click.argument("output-predicted-prefix", type=click.STRING, required=True)
@@ -50,14 +44,12 @@ def main(
     target_plot_file,
     output_predicted_prefix,
     output_zonal_prefix,
-    scale,
 ):
     # Get the model parameters
-    pixel_scale = scale == "PIXEL"
     parser = ppf.get_parameter_parser(parameter_file)
 
     # Create a NNFinder derived object - either pixel or plot
-    finder = PixelNNFinder(parser) if pixel_scale else PlotNNFinder(parser)
+    finder = PixelNNFinder(parser)
 
     # Read in the target IDs
     id_field = parser.plot_id_field

--- a/src/pynnmap/cli/new_targets.py
+++ b/src/pynnmap/cli/new_targets.py
@@ -8,30 +8,6 @@ from ..core.prediction_output import DependentOutput, IndependentOutput
 from ..parser import parameter_parser_factory as ppf
 
 
-def run_new_targets(
-    parser,
-    finder: PixelNNFinder,
-    target_fcids: list[int],
-    output_predicted_prefix: str,
-    output_zonal_prefix: str,
-) -> None:
-    # Calculate neighbors for the new target plots
-    neighbor_data = finder.calculate_neighbors_at_ids(target_fcids)
-
-    # Calculate independent and dependent predictive accuracy
-    independent_output = IndependentOutput(parser, neighbor_data)
-    independent_zonal_pixel_file = f"{output_zonal_prefix}_pixel_independent.csv"
-    independent_predicted_file = f"{output_predicted_prefix}_independent.csv"
-    independent_output.write_zonal_records(independent_zonal_pixel_file)
-    independent_output.write_attribute_predictions(independent_predicted_file)
-
-    dependent_output = DependentOutput(parser, neighbor_data)
-    dependent_zonal_pixel_file = f"{output_zonal_prefix}_pixel_dependent.csv"
-    dependent_predicted_file = f"{output_predicted_prefix}_dependent.csv"
-    dependent_output.write_zonal_records(dependent_zonal_pixel_file)
-    dependent_output.write_attribute_predictions(dependent_predicted_file)
-
-
 @click.command(
     name="new-targets", short_help="Run accuracy assessment on independent plots"
 )
@@ -48,13 +24,23 @@ def main(
     # Get the model parameters
     parser = ppf.get_parameter_parser(parameter_file)
 
-    # Create a NNFinder derived object - either pixel or plot
-    finder = PixelNNFinder(parser)
-
     # Read in the target IDs
     id_field = parser.plot_id_field
-    target_fcids = pd.read_csv(target_plot_file, usecols=[id_field])[id_field].tolist()
+    target_ids = pd.read_csv(target_plot_file, usecols=[id_field])[id_field].tolist()
 
-    run_new_targets(
-        parser, finder, target_fcids, output_predicted_prefix, output_zonal_prefix
-    )
+    # Calculate neighbors for the new target plots
+    finder = PixelNNFinder(parser)
+    neighbor_data = finder.calculate_neighbors_at_ids(target_ids)
+
+    # Calculate independent and dependent predictive accuracy
+    independent_output = IndependentOutput(parser, neighbor_data)
+    independent_zonal_pixel_file = f"{output_zonal_prefix}_pixel_independent.csv"
+    independent_predicted_file = f"{output_predicted_prefix}_independent.csv"
+    independent_output.write_zonal_records(independent_zonal_pixel_file)
+    independent_output.write_attribute_predictions(independent_predicted_file)
+
+    dependent_output = DependentOutput(parser, neighbor_data)
+    dependent_zonal_pixel_file = f"{output_zonal_prefix}_pixel_dependent.csv"
+    dependent_predicted_file = f"{output_predicted_prefix}_dependent.csv"
+    dependent_output.write_zonal_records(dependent_zonal_pixel_file)
+    dependent_output.write_attribute_predictions(dependent_predicted_file)

--- a/src/pynnmap/cli/new_targets.py
+++ b/src/pynnmap/cli/new_targets.py
@@ -1,9 +1,68 @@
+from __future__ import annotations
+
 import click
+import pandas as pd
+
+from ..core.nn_finder import PixelNNFinder, PlotNNFinder
+from ..core.prediction_output import DependentOutput, IndependentOutput
+from ..parser import parameter_parser_factory as ppf
+
+
+def run_new_targets(
+    parser,
+    finder: PixelNNFinder | PlotNNFinder,
+    target_fcids: list[int],
+    output_predicted_prefix: str,
+    output_zonal_prefix: str,
+) -> None:
+    # Calculate neighbors for the new target plots
+    neighbor_data = finder.calculate_neighbors_at_ids(target_fcids)
+
+    # Calculate independent and dependent predictive accuracy
+    independent_output = IndependentOutput(parser, neighbor_data)
+    independent_zonal_pixel_file = f"{output_zonal_prefix}_pixel_independent.csv"
+    independent_predicted_file = f"{output_predicted_prefix}_independent.csv"
+    independent_output.write_zonal_records(independent_zonal_pixel_file)
+    independent_output.write_attribute_predictions(independent_predicted_file)
+
+    dependent_output = DependentOutput(parser, neighbor_data)
+    dependent_zonal_pixel_file = f"{output_zonal_prefix}_pixel_dependent.csv"
+    dependent_predicted_file = f"{output_predicted_prefix}_dependent.csv"
+    dependent_output.write_zonal_records(dependent_zonal_pixel_file)
+    dependent_output.write_attribute_predictions(dependent_predicted_file)
 
 
 @click.command(
     name="new-targets", short_help="Run accuracy assessment on independent plots"
 )
+@click.option(
+    "--scale",
+    type=click.Choice(["PIXEL", "PLOT"], case_sensitive=False),
+    default="PIXEL",
+    help="Calculate accuracy at pixel or plot scale",
+)
 @click.argument("parameter-file", type=click.Path(exists=True), required=True)
-def main():
-    print("Not Implemented")
+@click.argument("target-plot-file", type=click.Path(exists=True), required=True)
+@click.argument("output-predicted-prefix", type=click.STRING, required=True)
+@click.argument("output-zonal-prefix", type=click.STRING, required=True)
+def main(
+    parameter_file,
+    target_plot_file,
+    output_predicted_prefix,
+    output_zonal_prefix,
+    scale,
+):
+    # Get the model parameters
+    pixel_scale = scale == "PIXEL"
+    parser = ppf.get_parameter_parser(parameter_file)
+
+    # Create a NNFinder derived object - either pixel or plot
+    finder = PixelNNFinder(parser) if pixel_scale else PlotNNFinder(parser)
+
+    # Read in the target IDs
+    id_field = parser.plot_id_field
+    target_fcids = pd.read_csv(target_plot_file, usecols=[id_field])[id_field].tolist()
+
+    run_new_targets(
+        parser, finder, target_fcids, output_predicted_prefix, output_zonal_prefix
+    )


### PR DESCRIPTION
This PR implements the `new_targets` entry point.  The script relies on the following inputs:

- __parameter-file__: The standard parameter file (typically `model.xml`)
- __target-plot-file__: A file with the new targets for which predicted attributes and neighbors should be collected.  The script expects that this file will have a field that matches the value of `nn_parameters.file_locations.plot_id_field`.
- __output-predicted-prefix__: The basename for where predicted output should be written.  Both independent and dependent predicted files are written with `_independent.csv` and `_dependent.csv` respectively appended to this prefix.
- __output-zonal-prefix__: The basename for where zonal output should be written.  Both independent and dependent zonal files are written with `_pixel_independent.csv` and `_pixel_dependent.csv` respectively appended to this prefix.

For this CLI program, we've gone away from specifying all parameters within the model configuration file which provides some flexibility in running new targets with more than one set of plots, such that output can be customized based on the output prefixes.

As of now, the option to run the analysis as either pixel-scale (neighbors are calculated for every pixel in a 3x3 plot footprint) or plot-scale (neighbors are calculated for the plot as a whole using mean values of `X` variables) has been disabled.  There is no guarantee in the current configuration that there will be `X` variables available for any plots that were not used in model fitting.  We may address this in a future PR.