### PR TITLE
Calculate cross validation accuracy assessment from stored pixel file

### DIFF
--- a/src/pynnmap/cli/cross_validate.py
+++ b/src/pynnmap/cli/cross_validate.py
@@ -36,11 +36,17 @@ def main(scale, parameter_file):
     pixel_scale = scale == "PIXEL"
     parser = ppf.get_parameter_parser(parameter_file)
 
-    # Create a NNFinder derived object - either pixel or plot
-    finder = PixelNNFinder(parser) if pixel_scale else PlotNNFinder(parser)
+    # Traditional route - extracting spatial information from plot locations
+    if not parser.environmental_pixel_file:
+        # Create a NNFinder derived object - either pixel or plot
+        finder = PixelNNFinder(parser) if pixel_scale else PlotNNFinder(parser)
 
-    # Run cross-validation to create the neighbor/distance information
-    run_cross_validate(parser, finder)
+        # Run cross-validation to create the neighbor/distance information
+        run_cross_validate(parser, finder)
+
+    # Fast route - using pre-stored spatial information at pixel locations
+    else:
+        pass
 
     # Calculate all accuracy diagnostics
     diagnostic_wrapper = dw.DiagnosticWrapper(parser)

--- a/src/pynnmap/cli/cross_validate.py
+++ b/src/pynnmap/cli/cross_validate.py
@@ -2,25 +2,10 @@ from __future__ import annotations
 
 import click
 
-from ..core.nn_finder import PixelNNFinder, PlotNNFinder
+from ..core.nn_finder import PixelNNFinder, PlotNNFinder, StoredPixelNNFinder
 from ..core.prediction_output import DependentOutput, IndependentOutput
 from ..diagnostics import diagnostic_wrapper as dw
 from ..parser import parameter_parser_factory as ppf
-
-
-def run_cross_validate(parser, finder: PixelNNFinder | PlotNNFinder) -> None:
-    # Run cross-validation to create the neighbor/distance information
-    neighbor_data = finder.calculate_neighbors_cross_validation()
-
-    # Calculate independent and dependent predictive accuracy
-    independent_output = IndependentOutput(parser, neighbor_data)
-    independent_output.write_zonal_records(parser.independent_zonal_pixel_file)
-    independent_output.write_attribute_predictions(parser.independent_predicted_file)
-
-    dependent_output = DependentOutput(parser, neighbor_data)
-    dependent_output.write_zonal_records(parser.dependent_zonal_pixel_file)
-    dependent_output.write_attribute_predictions(parser.dependent_predicted_file)
-    dependent_output.write_nn_index_file(neighbor_data, parser.dependent_nn_index_file)
 
 
 @click.command(name="cross-validate", short_help="Accuracy assessment for model plots")
@@ -36,17 +21,29 @@ def main(scale, parameter_file):
     pixel_scale = scale == "PIXEL"
     parser = ppf.get_parameter_parser(parameter_file)
 
-    # Traditional route - extracting spatial information from plot locations
-    if not parser.environmental_pixel_file:
-        # Create a NNFinder derived object - either pixel or plot
-        finder = PixelNNFinder(parser) if pixel_scale else PlotNNFinder(parser)
-
-        # Run cross-validation to create the neighbor/distance information
-        run_cross_validate(parser, finder)
-
-    # Fast route - using pre-stored spatial information at pixel locations
+    # Determine the NNFinder type
+    if pixel_scale:
+        # Traditional route - extracting spatial information from plot locations
+        if not parser.environmental_pixel_file:
+            nn_finder = PixelNNFinder(parser)
+        # Fast route - using pre-stored spatial information at pixel locations
+        else:
+            nn_finder = StoredPixelNNFinder(parser)
     else:
-        pass
+        nn_finder = PlotNNFinder(parser)
+
+    # Run cross-validation to create the neighbor/distance information
+    neighbor_data = nn_finder.calculate_neighbors_cross_validation()
+
+    # Calculate independent and dependent predictive accuracy
+    independent_output = IndependentOutput(parser, neighbor_data)
+    independent_output.write_zonal_records(parser.independent_zonal_pixel_file)
+    independent_output.write_attribute_predictions(parser.independent_predicted_file)
+
+    dependent_output = DependentOutput(parser, neighbor_data)
+    dependent_output.write_zonal_records(parser.dependent_zonal_pixel_file)
+    dependent_output.write_attribute_predictions(parser.dependent_predicted_file)
+    dependent_output.write_nn_index_file(neighbor_data, parser.dependent_nn_index_file)
 
     # Calculate all accuracy diagnostics
     diagnostic_wrapper = dw.DiagnosticWrapper(parser)

--- a/src/pynnmap/cli/find_outliers.py
+++ b/src/pynnmap/cli/find_outliers.py
@@ -14,11 +14,17 @@ def main(parameter_file):
     # Get the model parameters
     parser = ppf.get_parameter_parser(parameter_file)
 
-    # Create a PixelNNFinder object
-    finder = PixelNNFinder(parser)
+    # Traditional route - extracting spatial information from plot locations
+    if not parser.environmental_pixel_file:
+        # Create a PixelNNFinder object
+        finder = PixelNNFinder(parser)
 
-    # Run cross-validation to create the neighbor/distance information
-    run_cross_validate(parser, finder)
+        # Run cross-validation to create the neighbor/distance information
+        run_cross_validate(parser, finder)
+
+    # Fast route - using pre-stored spatial information at pixel locations
+    else:
+        pass
 
     # Run outlier analysis
     diagnostic_wrapper = dw.DiagnosticWrapper(parser)

--- a/src/pynnmap/core/nn_finder.py
+++ b/src/pynnmap/core/nn_finder.py
@@ -404,6 +404,33 @@ class PixelNNFinder(NNFinder):
         )
 
 
+class StoredPixelNNFinder(NNFinder):
+    """
+    A NNFinder that uses pre-stored spatial information at pixel locations.
+    """
+
+    def get_environmental_data(
+        self, plot_ids: NDArray
+    ) -> dict[int, list[EnvironmentalVector]]:
+        """
+        Get the environmental data for each plot ID at the pixel scale by
+        using the values in the environmental pixel file.
+        """
+        # Get the environmental pixel matrix and subset down to plot_ids
+        p = self.parameter_parser
+        subset_plot_df = pd.DataFrame({p.plot_id_field: plot_ids})
+        env_pixel_df = pd.read_csv(p.environmental_pixel_file)
+        env_pixel_df = subset_plot_df.merge(env_pixel_df, on=p.plot_id_field)
+
+        # Create an EnvironmentalVector for each plot_id
+        return {
+            plot_id: [
+                EnvironmentalVector(row) for row in group.to_dict(orient="records")
+            ]
+            for plot_id, group in env_pixel_df.groupby(p.plot_id_field)
+        }
+
+
 class PlotNNFinder(NNFinder):
     def get_environmental_data(
         self, plot_ids: NDArray

--- a/src/pynnmap/parser/xml_parameter_parser.py
+++ b/src/pynnmap/parser/xml_parameter_parser.py
@@ -265,6 +265,12 @@ class XMLParameterParser(xml_parser.XMLParser, parameter_parser.ParameterParser)
         return os.path.normpath(str(self.fl_elem.footprint_file))
 
     @property
+    def environmental_pixel_file(self):
+        if self.fl_elem.find("environmental_pixel_file") is not None:
+            return os.path.normpath(str(self.fl_elem.environmental_pixel_file))
+        return ""
+
+    @property
     def independent_predicted_file(self):
         file_name = str(self.fl_elem.independent_predicted_file)
         return self._get_path("independent_predicted_file", file_name)


### PR DESCRIPTION
Historically, for cross validation, plot ID values used in modeling are captured and then pixel-level values at plot footprints are extracted based on covariates in the model configuration.  This can be a long process although it remains necessary when obtaining new targets for which the user has no previously calculated covariate information.

However, for cross validation, a user can create a CSV file that stores pixel values for all covariates for all model plots and use this
information instead.  This PR creates a new `NNFinder` derived class (`StoredPixelNNFinder`) that simply reads in the CSV file and creates covariate information for the model plots.  The cross-validate CLI program looks for the presence of the `environmental_pixel_file` tag in the configuration and, if present, uses this class, otherwise defaults to the `PixelNNFinder` which does the extractions on the fly.