### PR TITLE
Skip pixels with NoData in `PixelNNFinder` and `StoredPixelNNFinder`

### DIFF
--- a/src/pynnmap/cli/cross_validate.py
+++ b/src/pynnmap/cli/cross_validate.py
@@ -27,10 +27,6 @@ def run_cross_validate(
     dependent_output.write_attribute_predictions(parser.dependent_predicted_file)
     dependent_output.write_nn_index_file(neighbor_data, parser.dependent_nn_index_file)
 
-    # Calculate all accuracy diagnostics
-    diagnostic_wrapper = dw.DiagnosticWrapper(parser)
-    diagnostic_wrapper.run_accuracy_diagnostics()
-
 
 @click.command(name="cross-validate", short_help="Accuracy assessment for model plots")
 @click.option(

--- a/src/pynnmap/diagnostics/diagnostic_wrapper.py
+++ b/src/pynnmap/diagnostics/diagnostic_wrapper.py
@@ -50,7 +50,7 @@ class DiagnosticWrapper:
                 diagnostic = kls.from_parameter_parser(p)
                 diagnostic.run_diagnostic()
             except utilities.MissingConstraintError as e:
-                print(e)
+                print(e.message)
 
     def run_outlier_diagnostics(self):
         p = self.parameter_parser

--- a/src/pynnmap/diagnostics/diagnostic_wrapper.py
+++ b/src/pynnmap/diagnostics/diagnostic_wrapper.py
@@ -50,7 +50,7 @@ class DiagnosticWrapper:
                 diagnostic = kls.from_parameter_parser(p)
                 diagnostic.run_diagnostic()
             except utilities.MissingConstraintError as e:
-                print(e.message)
+                print(e)
 
     def run_outlier_diagnostics(self):
         p = self.parameter_parser

--- a/src/pynnmap/misc/utilities.py
+++ b/src/pynnmap/misc/utilities.py
@@ -143,9 +143,9 @@ def subset_lines_from_regex(all_lines, start_re, end_re, skip_lines=0, flush=Fal
 
 
 class MissingConstraintError(Exception):
-    def __init__(self, message):
-        super().__init__()
-        self.message = message
+    """Raised when required files for a diagnostic are missing."""
+
+    ...
 
 
 def check_missing_files(files):


### PR DESCRIPTION
As a result of creating the `StoredPixelNNFinder` #17 and comparing it against the `PixelNNFinder`, we discovered that both finders were not handling NoData pixels correctly.  For `StoredPixelNNFinder`, it was a simple matter of using `.dropna` to remove any rows with NoData.  For `PixelNNFinder`, we first needed to read the rasters in with `masked=True` and then exclude any pixels where any covariate is a masked value.

This commit also includes two unrelated small fixes that should have been part of #17.